### PR TITLE
Use ARG in dockerfile to facilitate docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,16 @@ RUN cat /usr/local/share/sample_data/datadump* > /usr/local/share/sample_data/om
 FROM postgres:alpine
 
 # Define environment variable
-#ENV POSTGRES_USER omop_v5
-ENV POSTGRES_PASSWORD i3lworks
-#ENV POSTGRES_DB omop_v5
+ARG POSTGRES_USER
+ENV POSTGRES_USER $POSTGRES_USER
+ARG POSTGRES_PASSWORD
+ENV POSTGRES_PASSWORD $POSTGRES_PASSWORD
+ARG POSTGRES_DB
+ENV POSTGRES_DB $POSTGRES_DB
+
+# #ENV POSTGRES_USER omop_v5
+# ENV POSTGRES_PASSWORD i3lworks
+# #ENV POSTGRES_DB omop_v5
 
 # Copy omop_v5_dump.tgz to the /opt/data/ folder
 COPY --from=dumpbuilder /usr/local/share/sample_data/omop_v5_dump.tgz /opt/data/omop_v5_dump.tgz


### PR DESCRIPTION
To spin up ompoonfhir-main we need a omopv5fhir-pgsql running. 
It's easier to setup things with ARGs than to change the Dockerfile with the credentials.

This, however might break someone's flow..

Eg, a compose would look like:
```
# docker-compose.yml
version: '3'
services:
  omopv5fhir-pgsql:
    build:
      context: "./omopv5fhir-pgsql/"
      dockerfile: Dockerfile
      args:
        - POSTGRES_USER=omop_v5
        - POSTGRES_PASSWORD=i3lworks
        - POSTGRES_DB=omop_v5
    restart: always
    ports:
      - "5432:5432"

  omoponfhir:
    build:
      context: "./omoponfhir-main"
      dockerfile: Dockerfile
    depends_on:
      - omopv5fhir-pgsql
    restart: always
    ports:
      - "8080:8080"
    environment:
      - JDBC_URL=jdbc:postgresql://omopv5fhir-pgsql:5432/omop_v5
      - JDBC_USERNAME=omop_v5
      - JDBC_PASSWORD=i3lworks
```